### PR TITLE
add hyper-loaded-defined classes

### DIFF
--- a/directives/hyper-bind.js
+++ b/directives/hyper-bind.js
@@ -26,7 +26,7 @@ pkg.directive('hyperBind', [
           elem.text(format(value));
 
           if (status.isLoaded(value)) return status.loaded(elem);
-          return status.loading(elem);
+          return status.undef(elem);
         });
       }
     };

--- a/directives/hyper-form.js
+++ b/directives/hyper-form.js
@@ -61,7 +61,7 @@ pkg.directive('hyperForm', [
           delete $scope.submit;
           delete $scope.reset;
 
-          return status.loading(elem);
+          return status.undef(elem);
         }
 
         function getInputs(inputs, $scope) {

--- a/directives/hyper-img.js
+++ b/directives/hyper-img.js
@@ -41,7 +41,7 @@ pkg.directive('hyperImg', [
           elem.prop('alt', title);
 
           if (isLoaded) return status.loaded(elem);
-          return status.loading(elem);
+          return status.undef(elem);
         });
       }
     };

--- a/directives/hyper.js
+++ b/directives/hyper.js
@@ -40,7 +40,7 @@ pkg.directive('hyper', [
             $scope[t] = merge($scope[t], value);
 
             if (status.isLoaded(value)) return status.loaded(elem);
-            return status.loading(elem);
+            return status.undef(elem);
           });
         });
       }

--- a/services/hyper-status.js
+++ b/services/hyper-status.js
@@ -17,7 +17,15 @@ pkg.factory('hyperStatus', [
       },
       loaded: function(elem) {
         elem.removeClass('ng-hyper-loading');
+        elem.removeClass('ng-hyper-loaded-undefined');
         elem.addClass('ng-hyper-loaded');
+        elem.addClass('ng-hyper-loaded-defined');
+      },
+      undef: function(elem) {
+        elem.removeClass('ng-hyper-loading');
+        elem.removeClass('ng-hyper-loaded-defined');
+        elem.addClass('ng-hyper-loaded');
+        elem.addClass('ng-hyper-loaded-undefined');
       },
       isLoaded: function(value) {
         return typeof value !== 'undefined';

--- a/style.css
+++ b/style.css
@@ -1,3 +1,4 @@
-.ng-hyper-loading {
+.ng-hyper-loading,
+.ng-hyper-loaded-undefined {
   display: none;
 }

--- a/test/directives.test.js
+++ b/test/directives.test.js
@@ -5,18 +5,21 @@ describe('directives', function() {
     it('should load a value into the scope', function() {
       var elem = html('<div hyper=".users.key"></div>');
       expect(elem).toBeLoaded();
+      expect(elem).toBeHyperDefined();
       expect(elem.scope().key).toBe('value');
     });
 
     it('should load a renamed value into the scope', function() {
       var elem = html('<div hyper=".users.key as other"></div>');
       expect(elem).toBeLoaded();
+      expect(elem).toBeHyperDefined();
       expect(elem.scope().other).toBe('value');
     });
 
     it('should not be able to traverse a non-existant link', function() {
       var elem = html('<div hyper=".i-dont-exist"></div>');
-      expect(elem).not.toBeLoaded();
+      expect(elem).toBeLoaded();
+      expect(elem).not.toBeHyperDefined();
       expect(elem.scope()['i-dont-exist']).not.toBeDefined();
     });
 
@@ -38,7 +41,8 @@ describe('directives', function() {
       var elem = html('<div hyper=".users"><div hyper="users.non-existant.value"></div></div>');
       expect(elem).toBeLoaded();
       var child = elem.find('div');
-      expect(child).not.toBeLoaded();
+      expect(child).toBeLoaded();
+      expect(child).not.toBeHyperDefined();
       expect(child.scope().value).not.toBeDefined();
     });
 
@@ -79,7 +83,8 @@ describe('directives', function() {
 
     it('should not bind to a non-existant value', function() {
       var elem = html('<div hyper-bind=".users.non-existant"></div>');
-      expect(elem).not.toBeLoaded();
+      expect(elem).toBeLoaded();
+      expect(elem).not.toBeHyperDefined();
       expect(elem).toHaveText('');
     });
 
@@ -228,11 +233,19 @@ describe('directives', function() {
       toBeLoaded: function() {
         var not = this.isNot ? ' not' : '';
         this.message = function() {
-          return 'Expected ' + this.actual +  not + ' to be loaded';
+          return 'Expected ' + this.actual + not + ' to be loaded';
         };
 
         return this.actual.hasClass('ng-hyper-loaded')
           && !this.actual.hasClass('ng-hyper-loading');
+      },
+      toBeHyperDefined: function() {
+        var not = this.isNot ? ' not' : '';
+        this.message = function() {
+          return 'Expected ' + this.actual + not + ' to be hyper-defined';
+        };
+
+        return this.actual.hasClass('ng-hyper-loaded-defined');
       },
       toEndWith: function(text) {
         var not = this.isNot ? ' not' : '';


### PR DESCRIPTION
In the past there was no way to tell if the app was loading or had loaded but the value was undefined. This branch introduces two classes for that:
- `ng-hyper-loaded-defined`
- `ng-hyper-loaded-undefined`

The following conditions will now exist in the lifecycle of a binding:
- `ng-hyper-loading` the API has not returned a value yet
- `ng-hyper-loaded ng-hyper-loaded-defined` the API has returned a defined value for the given path
- `ng-hyper-loaded ng-hyper-loaded-undefined` the API has returned an undefined value for the given path

This feature should make it easier to do loading states that are only present during the initial state.
