### PR TITLE
apply classes to the input element

### DIFF
--- a/directives/hyper-input.js
+++ b/directives/hyper-input.js
@@ -18,10 +18,19 @@ pkg.directive('hyperInput', [
       scope: {
         input: '=hyperInput'
       },
-      link: function($scope, el, attrs) {
-        hyper.get('input.placeholder', $scope, function(placeholder) {
-          $scope.placeholder = placeholder;
-        });
+      compile: function compile(tElement, tAttrs) {
+        var inputClass = tAttrs.class;
+        tElement.removeClass(tAttrs.class);
+        return {
+          pre: function preLink(scope, iElement, iAttrs, controller) {
+            scope.inputClass = inputClass;
+          },
+          post: function postLink($scope, el, attrs) {
+            hyper.get('input.placeholder', $scope, function(placeholder) {
+              $scope.placeholder = placeholder;
+            });
+          }
+        };
       }
     };
   }

--- a/templates/inputs.html
+++ b/templates/inputs.html
@@ -1,5 +1,5 @@
 <div data-ng-class="{'ng-hyper-loading': !input, 'ng-hyper-loaded': input}" data-ng-switch="input.type">
-  <select data-ng-switch-when="select" name="{{input.name}}" data-ng-model="input.$model" data-ng-required="input.required" data-ng-disabled="input.disabled" data-hyper="input.options" data-ng-options="option.value as (option.name || option.text || option.value) for option in options"></select>
-  <textarea data-ng-switch-when="textarea" name="{{input.name}}" data-ng-model="input.$model" placeholder="{{placeholder || input.prompt || input.title || input.name}}" data-ng-required="input.required" data-ng-disabled="input.disabled"></textarea>
-  <input data-ng-switch-default name="{{input.name}}" data-ng-model="input.$model" type="{{input.type}}" placeholder="{{placeholder || input.prompt || input.title || input.name}}" data-ng-required="input.required" data-ng-disabled="input.disabled" />
+  <select data-ng-switch-when="select" name="{{input.name}}" data-ng-model="input.$model" data-ng-required="input.required" data-ng-disabled="input.disabled" data-hyper="input.options" data-ng-options="option.value as (option.name || option.text || option.value) for option in options" class="{{inputClass}}"></select>
+  <textarea data-ng-switch-when="textarea" name="{{input.name}}" data-ng-model="input.$model" placeholder="{{placeholder || input.prompt || input.title || input.name}}" data-ng-required="input.required" data-ng-disabled="input.disabled" class="{{inputClass}}"></textarea>
+  <input data-ng-switch-default name="{{input.name}}" data-ng-model="input.$model" type="{{input.type}}" placeholder="{{placeholder || input.prompt || input.title || input.name}}" data-ng-required="input.required" data-ng-disabled="input.disabled" class="{{inputClass}}" />
 </div>


### PR DESCRIPTION
@camshaft 
The classes used on the original element should be applied to the generated hyper input.

This should be done before anything is set to the scope so the classes relating to the directive don’t pollute what was specified on the element.
