### PR TITLE
bust cache in IE8+

### DIFF
--- a/ng-hyper.js
+++ b/ng-hyper.js
@@ -2656,7 +2656,9 @@ pkg.factory('hyperHttpEmitter', [
       var req = {
         headers: {
           'cache-control': 'no-cache, must-revalidate',
-          'pragma': 'no-cache'
+          'pragma': 'no-cache',
+          'expires': '-1',
+          'if-modified-since': '-1'
         },
         cache: cache
       };

--- a/services/hyper-backend-http.js
+++ b/services/hyper-backend-http.js
@@ -150,7 +150,9 @@ pkg.factory('hyperHttpEmitter', [
       var req = {
         headers: {
           'cache-control': 'no-cache, must-revalidate',
-          'pragma': 'no-cache'
+          'pragma': 'no-cache',
+          'expires': '-1',
+          'if-modified-since': '-1'
         },
         cache: cache
       };


### PR DESCRIPTION
Without these headers, IE8 and IE9 will fake a 304 response even when the server indicates otherwise.
